### PR TITLE
fix(api): Remove old files, used by mutler

### DIFF
--- a/packages/printweave-api/src/routes/printer.route.ts
+++ b/packages/printweave-api/src/routes/printer.route.ts
@@ -361,6 +361,8 @@ export function printerRoutes(printerId: number): Router {
 
         const response = await typedPrinter.uploadFile(req.file, printFileReport);
 
+        await fs.unlink(req.file.path);
+
         res.json({message: 'File uploaded', printFileReport, response});
 
     });


### PR DESCRIPTION
Removes all files that are older than 1 hour that were created because of a upload with mutler.
And removes file after upload to printer.